### PR TITLE
creates database table for MenuItemReview

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -25,7 +25,7 @@ public class MenuItemReview {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
   private long itemId;
-  private String reviewEmail;
+  private String reviewerEmail;
   private int stars;
   private LocalDateTime dateReviewed;
   private String comments;

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a MenuItemReview
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "MenuItemReviews")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private long itemId;
+  private String reviewEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDate entities.
+ */
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "oscar-luna",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEW"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEW_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "MENUITEMREVIEW"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
closes #26 
In This PR, we add a database table that represents MenuItemReview, with the following fields:

<img width="735" alt="Screenshot 2025-04-23 at 7 53 34 PM" src="https://github.com/user-attachments/assets/34bdb448-f373-4bc0-b929-ac5e58de6224" />

```
long itemId;
String reviewerEmail;
int stars;
LocalDateTime dateReviewed;
String comments;
```
You can test this by running on localhost and looking for the MenuItemReview table on the h2-console


<img width="207" alt="Screenshot 2025-04-23 at 7 52 42 PM" src="https://github.com/user-attachments/assets/e2c5afa0-7a5e-4e3e-a22d-f7e60f4c28eb" />



You can also test this by running on dokku and connecting to the postgres database, and running \dt.
<img width="620" alt="Screenshot 2025-04-23 at 7 51 17 PM" src="https://github.com/user-attachments/assets/5378229b-c5fb-413b-a4a9-3d4fbe53e523" />


