### PR TITLE
hj - create database table for help request

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "helprequests")  
+@Entity(name = "HelpRequests")  
 public class HelpRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "HelpRequests")
+@Entity(name = "helprequests")  
 public class HelpRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "HelpRequests")  
+@Entity(name = "helprequests")  
 public class HelpRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a Github HelpRequest.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "requests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "requests")
+@Entity(name = "HelpRequests")
 public class HelpRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest  ;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The HelpRequestRepository is a repository for HelpRequest entities.
+ */
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.HelpRequest  ;
+import edu.ucsb.cs156.example.entities.HelpRequest;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDates-1",
+          "author": "MattP",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDATES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDATES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "LOCAL_DATE_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "QUARTERYYYYQ",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDATES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -2,8 +2,8 @@
     "databaseChangeLog": [
       {
         "changeSet": {
-          "id": "UCSBDates-1",
-          "author": "MattP",
+          "id": "HelpRequest-1",
+          "author": "hjin133",
           "preConditions": [
             {
               "onFail": "MARK_RAN"
@@ -12,7 +12,7 @@
               "not": [
                 {
                   "tableExists": {
-                    "tableName": "UCSBDATES"
+                    "tableName": "HELPREQUESTS"
                   }
                 }
               ]
@@ -27,7 +27,7 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "UCSBDATES_PK"
+                        "primaryKeyName": "HELPREQUEST_PK"
                       },
                       "name": "ID",
                       "type": "BIGINT"
@@ -35,24 +35,43 @@
                   },
                   {
                     "column": {
-                      "name": "LOCAL_DATE_TIME",
-                      "type": "TIMESTAMP"
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "NAME",
+                      "name": "REQUESTER_EMAIL",
                       "type": "VARCHAR(255)"
                     }
                   },
                   {
                     "column": {
-                      "name": "QUARTERYYYYQ",
+                      "name": "TEAM_ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLE_OR_BREAKOUT_ROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUEST_TIME",
+                      "type": "TIMESTAMP WITH TIME ZONE "
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
                       "type": "VARCHAR(255)"
                     }
                   }
+
                 ],
-                "tableName": "UCSBDATES"
+                "tableName": "HELPREQUESTS"
               }
             }
           ]

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -66,7 +66,7 @@
                   {
                     "column": {
                       "name": "SOLVED",
-                      "type": "VARCHAR(255)"
+                      "type": "BOOLEAN"
                     }
                   }
 


### PR DESCRIPTION
Close #32
In this pr, we add a database table that represents a help request, with the following fields: 

...
String requesterEmail
String teamId
String tableOrBreakoutRoom
LocalDateTime requestTime
String explanation
boolean solved
...
You can test this by running on the local host and looking for the helprequests table on the H2 console

<img width="205" alt="截屏2025-04-24 下午7 02 58" src="https://github.com/user-attachments/assets/20ff601c-5cfb-4092-8113-41dc036b6862" />

You can also test this buy running on Dokku and connecting to Postgres database, and running \dt

...
hjin133@dokku-01:~$ dokku postgres:connect team01-dev-hjin133-db 
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_hjin133_db=# \dt
                 List of relations
 Schema |         Name          | Type  |  Owner   
--------+-----------------------+-------+----------
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | helprequests          | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | users                 | table | postgres
(7 rows)

team01_dev_hjin133_db=# 
...